### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,10 +179,8 @@ The account would now have one primary key with weight 3, and three associated a
 
 ### NOTES
 
-1. The `deployment` threshold must be changed before the `key_management` threshold can be updated.
-2. The primary key on the account can lower its weight if it has enough weight to meet the `key_mangement` threshold.
-3. All associated keys should be kept incredibly secure to ensure the security and integrity of the account.
-4. After all associated keys and action thresholds have been set to the desired multi-signature scheme, the weight of the original primary key can be increased or lowered, depending on your use case. Be careful with this, though. If you lower the primary key's weight below the key management threshold, the account will require multiple signatures for future key management. You must have enough associated keys set up. Otherwise, the account will be unusable.
+1. All associated keys should be kept incredibly secure to ensure the security and integrity of the account.
+2. After all associated keys and action thresholds have been set to the desired multi-signature scheme, the weight of the original primary key can be increased or lowered, depending on your use case. Be careful with this! If you lower the primary key's weight below the key management threshold, the account will require multiple signatures for key management. The account will be unusable if you do not have enough associated keys set up.
 
 ## Step 6: Send a multi-signature deploy from the primary account
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The account's action thresholds would look like this:
 
 ## Step 5: Add associated keys to the primary account
 
-To add an associated key to the primary account, use the `add_account.wasm` provided. This example adds two keys (`account-hash-e2d0...`, `account-hash-04a9...`) with weight 1 to the primary account (`account-hash-d89c...`).
+To add an associated key to the primary account, use the `add_account.wasm` provided. This example adds two keys to the primary account (`account-hash-d89c...`): `user_1` with `account-hash-e2d0...`, and `user_2` with `account-hash-04a9...`.
 
 ### FOR EXAMPLE ONLY, PLEASE UPDATE PRIOR TO EXECUTING
 

--- a/README.md
+++ b/README.md
@@ -136,28 +136,28 @@ The account would now have one primary key with weight 3, and two associated acc
 
 ```json
 "Account": {
+  "account_hash": "account-hash-1ed5a1c39bea93c105f2d22c965a84b205b36734a377d05dbb103b6bfaa595a7",
+  "action_thresholds": {
+    "deployment": 2,
+    "key_management": 3
+  },
+  "associated_keys": [
+    {
+      "account_hash": "account-hash-04a9691a9f8f05a0f08bd686f188b27c7dbcd644b415759fd3ca043d916ea02f",
+      "weight": 1
+    },
+    {
       "account_hash": "account-hash-1ed5a1c39bea93c105f2d22c965a84b205b36734a377d05dbb103b6bfaa595a7",
-      "action_thresholds": {
-        "deployment": 2,
-        "key_management": 3
-      },
-      "associated_keys": [
-        {
-          "account_hash": "account-hash-04a9691a9f8f05a0f08bd686f188b27c7dbcd644b415759fd3ca043d916ea02f",
-          "weight": 1
-        },
-        {
-          "account_hash": "account-hash-1ed5a1c39bea93c105f2d22c965a84b205b36734a377d05dbb103b6bfaa595a7",
-          "weight": 3
-        },
-        {
-          "account_hash": "account-hash-e2d00525cac31ae2756fb155f289d276c6945b6914923fe275de0cb127bffee7",
-          "weight": 1
-        }
-      ],
-      "main_purse": "uref-8294864177c2c1ec887a11dae095e487b5256ce6bd2a1f2740d0e4f28bd3251c-007",
-      "named_keys": []
+      "weight": 3
+    },
+    {
+      "account_hash": "account-hash-e2d00525cac31ae2756fb155f289d276c6945b6914923fe275de0cb127bffee7",
+      "weight": 1
     }
+  ],
+  "main_purse": "uref-8294864177c2c1ec887a11dae095e487b5256ce6bd2a1f2740d0e4f28bd3251c-007",
+  "named_keys": []
+}
 ```
 
 </details>
@@ -263,32 +263,32 @@ casper-client put-deploy --node-address https://rpc.testnet.casperlabs.io/ \
 
 ```json
 "Account": {
+  "account_hash": "account-hash-1ed5a1c39bea93c105f2d22c965a84b205b36734a377d05dbb103b6bfaa595a7",
+  "action_thresholds": {
+    "deployment": 2,
+    "key_management": 3
+  },
+  "associated_keys": [
+    {
+      "account_hash": "account-hash-04a9691a9f8f05a0f08bd686f188b27c7dbcd644b415759fd3ca043d916ea02f",
+      "weight": 1
+    },
+    {
+      "account_hash": "account-hash-1fed34baa6807a7868bb18f91b161d99ebf21763810fe4c92e39775d10bbf1f8",
+      "weight": 1
+    },
+    {
       "account_hash": "account-hash-1ed5a1c39bea93c105f2d22c965a84b205b36734a377d05dbb103b6bfaa595a7",
-      "action_thresholds": {
-        "deployment": 2,
-        "key_management": 3
-      },
-      "associated_keys": [
-        {
-          "account_hash": "account-hash-04a9691a9f8f05a0f08bd686f188b27c7dbcd644b415759fd3ca043d916ea02f",
-          "weight": 1
-        },
-        {
-          "account_hash": "account-hash-1fed34baa6807a7868bb18f91b161d99ebf21763810fe4c92e39775d10bbf1f8",
-          "weight": 1
-        },
-        {
-          "account_hash": "account-hash-1ed5a1c39bea93c105f2d22c965a84b205b36734a377d05dbb103b6bfaa595a7",
-          "weight": 3
-        },
-        {
-          "account_hash": "account-hash-e2d00525cac31ae2756fb155f289d276c6945b6914923fe275de0cb127bffee7",
-          "weight": 1
-        }
-      ],
-      "main_purse": "uref-8294864177c2c1ec887a11dae095e487b5256ce6bd2a1f2740d0e4f28bd3251c-007",
-      "named_keys": []
+      "weight": 3
+    },
+    {
+      "account_hash": "account-hash-e2d00525cac31ae2756fb155f289d276c6945b6914923fe275de0cb127bffee7",
+      "weight": 1
     }
+  ],
+  "main_purse": "uref-8294864177c2c1ec887a11dae095e487b5256ce6bd2a1f2740d0e4f28bd3251c-007",
+  "named_keys": []
+}
 ```
 
 </details>
@@ -313,28 +313,28 @@ The resulting account should not contain the associated key that was just remove
 
 ```json
 "Account": {
+  "account_hash": "account-hash-1ed5a1c39bea93c105f2d22c965a84b205b36734a377d05dbb103b6bfaa595a7",
+  "action_thresholds": {
+    "deployment": 2,
+    "key_management": 3
+  },
+  "associated_keys": [
+    {
+      "account_hash": "account-hash-04a9691a9f8f05a0f08bd686f188b27c7dbcd644b415759fd3ca043d916ea02f",
+      "weight": 1
+    },
+    {
       "account_hash": "account-hash-1ed5a1c39bea93c105f2d22c965a84b205b36734a377d05dbb103b6bfaa595a7",
-      "action_thresholds": {
-        "deployment": 2,
-        "key_management": 3
-      },
-      "associated_keys": [
-        {
-          "account_hash": "account-hash-04a9691a9f8f05a0f08bd686f188b27c7dbcd644b415759fd3ca043d916ea02f",
-          "weight": 1
-        },
-        {
-          "account_hash": "account-hash-1ed5a1c39bea93c105f2d22c965a84b205b36734a377d05dbb103b6bfaa595a7",
-          "weight": 3
-        },
-        {
-          "account_hash": "account-hash-e2d00525cac31ae2756fb155f289d276c6945b6914923fe275de0cb127bffee7",
-          "weight": 1
-        }
-      ],
-      "main_purse": "uref-8294864177c2c1ec887a11dae095e487b5256ce6bd2a1f2740d0e4f28bd3251c-007",
-      "named_keys": []
+      "weight": 3
+    },
+    {
+      "account_hash": "account-hash-e2d00525cac31ae2756fb155f289d276c6945b6914923fe275de0cb127bffee7",
+      "weight": 1
     }
+  ],
+  "main_purse": "uref-8294864177c2c1ec887a11dae095e487b5256ce6bd2a1f2740d0e4f28bd3251c-007",
+  "named_keys": []
+}
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -168,41 +168,21 @@ The account would now have one primary key with weight 3, and two associated acc
 1. All associated keys should be kept incredibly secure to ensure the security and integrity of the account.
 2. After all associated keys and action thresholds have been set to the desired multi-signature scheme, the weight of the original primary key can be increased or lowered, depending on your use case. Be careful with this! If you lower the primary key's weight below the key management threshold, the account will require multiple signatures for key management. The account will be unusable if you do not have enough associated keys set up.
 
-## Step 6: Send a multi-signature deploy from the primary account
+## Step 6: Send a deploy from the primary account
 
-After setting up the account with a multi-signature scheme, use the following commands to sign a deploy with multiple keys and send it to the network:
-
-1. `make-deploy` - creates and signs a deploy, saving the output to a file
-2. `sign-deploy` - adds additional signatures for a multi-signature deploy
-3. `send-deploy` - sends the deploy to the network
-
-The following example sends a multi-sig deploy containing Wasm (`hello_world.wasm`) that adds a named key to the account. The deploy originates from the primary account and needs two signatures to meet the `deployment` weight set to 2. Once both keys sign the deploy, either can send it to the network. The Wasm used here can be found in the [hello-world](https://github.com/casper-ecosystem/hello-world) repository.
+This example sends a deploy containing Wasm (`contract.wasm`), which adds a named key to the account. The source code for the Wasm comes from the [hello-world](https://github.com/casper-ecosystem/hello-world) repository. The deploy should succeed as the primary account has a weight of 3, which is greater than the deployment threshold.
 
 ### FOR EXAMPLE ONLY, PLEASE UPDATE PRIOR TO EXECUTING
 
 The first associated key creates and signs the deploy with the `make-deploy` command.
 
 ```bash
-casper-client make-deploy --chain-name casper-test \
+casper-client put-deploy --chain-name casper-test \
 --payment-amount 3000000000 \
 --session-path tests/wasm/contract.wasm \
 --secret-key $PATH/secret_key.pem \
 --session-arg "my-key-name:string='user_1_key'" \
---session-arg "message:string='Hello, World'" \
---output hello_world_one_signature
-```
-
-The second associated key signs the deploy with `sign-deploy` to meet the deployment threshold for the account.
-
-```bash
-casper-client sign-deploy -i hello_world_one_signature -k ~/cspr_nctl/user-2.pem -o hello_world_two_signatures
-
-```
-
-Now the deploy can be sent to the network with the `send-deploy` command:
-
-```bash
-casper-client send-deploy --node-address https://rpc.testnet.casperlabs.io -i hello_world_two_signatures
+--session-arg "message:string='Hello, World'"
 ```
 
 The `hello_world.wasm` will run and add a named key to the account.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The account's action thresholds would look like this:
 
 ## Step 5: Add associated keys to the primary account
 
-To add an associated key to the primary account, use the `add_account.wasm` provided. The example below starts by adding the following account as an associated key: `account-hash-e2d00525cac31ae2756fb155f289d276c6945b6914923fe275de0cb127bffee7`.
+To add an associated key to the primary account, use the `add_account.wasm` provided. This example adds two keys (`account-hash-e2d0...`, `account-hash-04a9...`) with weight 1 to the primary account (`account-hash-d89c...`).
 
 ### FOR EXAMPLE ONLY, PLEASE UPDATE PRIOR TO EXECUTING
 
@@ -120,8 +120,6 @@ casper-client put-deploy --node-address https://rpc.testnet.casperlabs.io/ \
 --session-arg "weight:u8='1'"
 ```
 
-Next, add a second and third account as associated keys with weight 1.
-
 ```bash
 casper-client put-deploy --node-address https://rpc.testnet.casperlabs.io/ \
 --chain-name "casper-test" \
@@ -130,17 +128,9 @@ casper-client put-deploy --node-address https://rpc.testnet.casperlabs.io/ \
 --session-path target/wasm32-unknown-unknown/release/add_account.wasm \
 --session-arg "new_key:key='account-hash-04a9691a9f8f05a0f08bd686f188b27c7dbcd644b415759fd3ca043d916ea02f" \
 --session-arg "weight:u8='1'"
-
-casper-client put-deploy --node-address https://rpc.testnet.casperlabs.io/ \
---chain-name "casper-test" \
---payment-amount 500000000 \
---secret-key $PATH/secret_key.pem \
---session-path target/wasm32-unknown-unknown/release/add_account.wasm \
---session-arg "new_key:key='account-hash-1fed34baa6807a7868bb18f91b161d99ebf21763810fe4c92e39775d10bbf1f8" \
---session-arg "weight:u8='1'"
 ```
 
-The account would now have one primary key with weight 3, and three associated accounts, each with weight 1.
+The account would now have one primary key with weight 3, and two associated accounts, each with weight 1.
 
 <details>
 <summary>Account details</summary>
@@ -155,10 +145,6 @@ The account would now have one primary key with weight 3, and three associated a
       "associated_keys": [
         {
           "account_hash": "account-hash-04a9691a9f8f05a0f08bd686f188b27c7dbcd644b415759fd3ca043d916ea02f",
-          "weight": 1
-        },
-        {
-          "account_hash": "account-hash-1fed34baa6807a7868bb18f91b161d99ebf21763810fe4c92e39775d10bbf1f8",
           "weight": 1
         },
         {

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ Update the weight of the primary key to 3 by calling the `update_associated_keys
 ```bash
 casper-client put-deploy --node-address https://rpc.testnet.casperlabs.io/ \
 --chain-name "casper-test" \
---payment-amount 2000000000 \
---secret-key /path/to/keys_dir/secret_key.pem \
---session-path contracts/update_keys/target/wasm32-unknown-unknown/release/update_associated_keys.wasm \
---session-arg "associated_key:account_hash='account-hash-<ACCOUNT_HASH_HEX_HERE>'" \
+--payment-amount 500000000 \
+--secret-key $PATH/secret_key.pem \
+--session-path target/wasm32-unknown-unknown/release/update_associated_keys.wasm \
+--session-arg "associated_key:key='account-hash-<ACCOUNT_HASH_HEX_HERE>'" \
 --session-arg "new_weight:u8='3'"
 ```
 
@@ -87,9 +87,11 @@ Set up a multi-signature scheme for the account, by updating the `deployment` an
 casper-client put-deploy \
 --node-address https://rpc.testnet.casperlabs.io \
 --chain-name casper-test \
---payment-amount 5000000000 \
---secret-key /path/to/keys_dir/secret_key.pem \
---session-path contracts/update_thresholds/target/wasm32-unknown-unknown/release/update_thresholds.wasm
+--payment-amount 500000000 \
+--secret-key $PATH/secret_key.pem \
+--session-path target/wasm32-unknown-unknown/release/update_thresholds.wasm \
+--session-arg "deployment_threshold:u8='2'" \
+--session-arg "key_management_threshold:u8='3'"
 ```
 
 The account's action thresholds would look like this:
@@ -111,10 +113,10 @@ To add an associated key to the primary account, use the `add_account.wasm` prov
 ```bash
 casper-client put-deploy --node-address https://rpc.testnet.casperlabs.io/ \
 --chain-name "casper-test" \
---payment-amount 50000000000 \
---secret-key /path/to/keys_dir/secret_key.pem \
---session-path contracts/add_account/target/wasm32-unknown-unknown/release/add_account.wasm \
---session-arg "new_key:account_hash='account-hash-e2d00525cac31ae2756fb155f289d276c6945b6914923fe275de0cb127bffee7" \
+--payment-amount 500000000 \
+--secret-key $PATH/secret_key.pem \
+--session-path target/wasm32-unknown-unknown/release/add_account.wasm \
+--session-arg "new_key:key='account-hash-e2d00525cac31ae2756fb155f289d276c6945b6914923fe275de0cb127bffee7" \
 --session-arg "weight:u8='1'"
 ```
 
@@ -123,18 +125,18 @@ Next, add a second and third account as associated keys with weight 1.
 ```bash
 casper-client put-deploy --node-address https://rpc.testnet.casperlabs.io/ \
 --chain-name "casper-test" \
---payment-amount 50000000000 \
---secret-key /path/to/keys_dir/secret_key.pem \
---session-path contracts/add_account/target/wasm32-unknown-unknown/release/add_account.wasm \
---session-arg "new_key:account_hash='account-hash-04a9691a9f8f05a0f08bd686f188b27c7dbcd644b415759fd3ca043d916ea02f" \
+--payment-amount 500000000 \
+--secret-key $PATH/secret_key.pem \
+--session-path target/wasm32-unknown-unknown/release/add_account.wasm \
+--session-arg "new_key:key='account-hash-04a9691a9f8f05a0f08bd686f188b27c7dbcd644b415759fd3ca043d916ea02f" \
 --session-arg "weight:u8='1'"
 
 casper-client put-deploy --node-address https://rpc.testnet.casperlabs.io/ \
 --chain-name "casper-test" \
---payment-amount 50000000000 \
---secret-key /path/to/keys_dir/secret_key.pem \
---session-path contracts/add_account/target/wasm32-unknown-unknown/release/add_account.wasm \
---session-arg "new_key:account_hash='account-hash-1fed34baa6807a7868bb18f91b161d99ebf21763810fe4c92e39775d10bbf1f8" \
+--payment-amount 500000000 \
+--secret-key $PATH/secret_key.pem \
+--session-path target/wasm32-unknown-unknown/release/add_account.wasm \
+--session-arg "new_key:key='account-hash-1fed34baa6807a7868bb18f91b161d99ebf21763810fe4c92e39775d10bbf1f8" \
 --session-arg "weight:u8='1'"
 ```
 
@@ -199,8 +201,8 @@ The first associated key creates and signs the deploy with the `make-deploy` com
 ```bash
 casper-client make-deploy --chain-name casper-test \
 --payment-amount 3000000000 \
---session-path contracts/hello_world/target/wasm32-unknown-unknown/release/hello_world.wasm \
---secret-key /path/to/keys_dir/secret_key.pem \
+--session-path tests/wasm/contract.wasm \
+--secret-key $PATH/secret_key.pem \
 --session-arg "my-key-name:string='user_1_key'" \
 --session-arg "message:string='Hello, World'" \
 --output hello_world_one_signature
@@ -241,8 +243,8 @@ One associated key creates and signs the deploy with the `make-deploy` command, 
 ```bash
 casper-client make-deploy --chain-name casper-test \
 --payment-amount 3000000000 \
---session-path contracts/hello_world/target/wasm32-unknown-unknown/release/hello_world.wasm \
---secret-key /path/to/keys_dir/secret_key.pem \
+--session-path tests/wasm/contract.wasm \
+--secret-key $PATH/secret_key.pem \
 --session-arg "my-key-name:string='user_1_key'" \
 --session-arg "message:string='Hello, World'" \
 --session-account 04a9691a9f8f05a0f08bd686f188b27c7dbcd644b415759fd3ca043d916ea02f \
@@ -277,10 +279,10 @@ Given the current setup, three associated keys need to sign the deploy to add a 
 
 ```bash
 casper-client make-deploy --chain-name casper-test \
---payment-amount 50000000000 \
---secret-key /path/to/keys_dir/secret_key.pem \
---session-path contracts/add_account/target/wasm32-unknown-unknown/release/add_account.wasm \
---session-arg "new_key:account_hash='account-hash-77ea2e433c94c9cb8303942335da458672249d38c1fa5d1d7a7500b862ff52a4" \
+--payment-amount 500000000 \
+--secret-key $PATH/secret_key.pem \
+--session-path target/wasm32-unknown-unknown/release/add_account.wasm \
+--session-arg "new_key:key='account-hash-77ea2e433c94c9cb8303942335da458672249d38c1fa5d1d7a7500b862ff52a4" \
 --session-arg "weight:u8='1'" \
 --output add_account_one_signature
 ```
@@ -347,10 +349,10 @@ One associated key creates and signs the deploy with the `make-deploy` command.
 
 ```bash
 casper-client make-deploy --chain-name casper-test \
---payment-amount 50000000000 \
---secret-key /path/to/keys_dir/secret_key.pem \
---session-path contracts/add_account/target/wasm32-unknown-unknown/release/remove_account.wasm \
---session-arg "new_key:account_hash='account-hash-77ea2e433c94c9cb8303942335da458672249d38c1fa5d1d7a7500b862ff52a4" \
+--payment-amount 500000000 \
+--secret-key $PATH/secret_key.pem \
+--session-path target/wasm32-unknown-unknown/release/remove_account.wasm \
+--session-arg "new_key:key='account-hash-77ea2e433c94c9cb8303942335da458672249d38c1fa5d1d7a7500b862ff52a4" \
 --session-arg "weight:u8='1'" \
 --output remove_account_one_signature
 ```

--- a/README.md
+++ b/README.md
@@ -253,38 +253,23 @@ The `hello_world.wasm` will run and add a named key to the account.
 
 ## Removing a compromised key from the account
 
-This example shows how to remove a key that may have been compromised. The example adds another associated key  only to remove it using the `remove_account.wasm` session code. 
+This example shows how to remove a compromised key from an account. The example adds an associated key only to remove it using the `remove_account.wasm` session code.
 
 >**Caution**: Before removing a key, ensure the remaining associated keys can combine their weight to meet the threshold for key management. Otherwise, the account could become unusable. Changing key weights or adding new associated keys would only be possible by meeting the key management threshold. Proceed with caution.
 
 ### FOR EXAMPLE ONLY, PLEASE UPDATE PRIOR TO EXECUTING
 
-Given the current setup, three associated keys need to sign the deploy to add a fourth associated key. One associated key creates and signs the deploy with the `make-deploy` command.
+Given the current setup, the primary account will add an associated key, and then remove it. In other use cases, associated keys may need to combine their signatures to send a multi-sig deploy that removes a key.
 
 ```bash
-casper-client make-deploy --chain-name casper-test \
+casper-client put-deploy --node-address https://rpc.testnet.casperlabs.io/ \
+--chain-name "casper-test" \
 --payment-amount 500000000 \
 --secret-key $PATH/secret_key.pem \
 --session-path target/wasm32-unknown-unknown/release/add_account.wasm \
---session-arg "new_key:key='account-hash-77ea2e433c94c9cb8303942335da458672249d38c1fa5d1d7a7500b862ff52a4" \
---session-arg "weight:u8='1'" \
---output add_account_one_signature
+--session-arg "new_key:key='account-hash-1fed34baa6807a7868bb18f91b161d99ebf21763810fe4c92e39775d10bbf1f8" \
+--session-arg "weight:u8='1'"
 ```
-
-The second and third associated keys sign the deploy with `sign-deploy` to meet the key management threshold for the account.
-
-```bash
-casper-client sign-deploy -i add_account_one_signature -k ~/cspr_nctl/user-2.pem -o add_account_two_signatures
-casper-client sign-deploy -i add_account_two_signatures -k ~/cspr_nctl/user-3.pem -o add_account_three_signatures
-```
-
-Send the deploy containing the `add_account.wasm` to add a new associated account with weight 1.
-
-```bash
-casper-client send-deploy --node-address https://rpc.testnet.casperlabs.io -i add_account_three_signatures
-```
-
-The account should now have four associated keys with weight 1 and the primary key (from which all deploys originate) with weight 3.
 
 <details>
 <summary>Account details</summary>
@@ -303,10 +288,6 @@ The account should now have four associated keys with weight 1 and the primary k
         },
         {
           "account_hash": "account-hash-1fed34baa6807a7868bb18f91b161d99ebf21763810fe4c92e39775d10bbf1f8",
-          "weight": 1
-        },
-        {
-          "account_hash": "account-hash-77ea2e433c94c9cb8303942335da458672249d38c1fa5d1d7a7500b862ff52a4",
           "weight": 1
         },
         {
@@ -325,43 +306,23 @@ The account should now have four associated keys with weight 1 and the primary k
 
 </details>
 
-The `remove_account.wasm` will remove the newly added account to demonstrate the possibility of removing associated keys that may have been compromised. This deploy needs to be signed by three associated keys to meet the key management threshold.
-
-One associated key creates and signs the deploy with the `make-deploy` command.
-
-### FOR EXAMPLE ONLY, PLEASE UPDATE PRIOR TO EXECUTING
-
-```bash
-casper-client make-deploy --chain-name casper-test \
---payment-amount 500000000 \
---secret-key $PATH/secret_key.pem \
---session-path target/wasm32-unknown-unknown/release/remove_account.wasm \
---session-arg "new_key:key='account-hash-77ea2e433c94c9cb8303942335da458672249d38c1fa5d1d7a7500b862ff52a4" \
---session-arg "weight:u8='1'" \
---output remove_account_one_signature
-```
-
-The second and third associated keys sign the deploy with `sign-deploy` to meet the key management threshold for the account.
-
-```bash
-casper-client sign-deploy -i remove_account_one_signature -k ~/cspr_nctl/user-2.pem -o remove_account_two_signatures
-casper-client sign-deploy -i remove_account_two_signatures -k ~/cspr_nctl/user-3.pem -o remove_account_three_signatures
-```
-
-Send the deploy to the network to remove an associated key.
+The `remove_account.wasm` will remove the newly added account to demonstrate the possibility of removing associated keys that may have been compromised.
 
 ### REMOVE KEYS WITH CAUTION! DO NOT RUN THIS EXAMPLE ON MAINNET
 
 ```bash
-casper-client send-deploy --node-address https://rpc.testnet.casperlabs.io -i remove_account_three_signatures
+casper-client put-deploy --node-address https://rpc.testnet.casperlabs.io/ \
+--chain-name "casper-test" \
+--payment-amount 500000000 \
+--secret-key $PATH/secret_key.pem \
+--session-path target/wasm32-unknown-unknown/release/remove_account.wasm \
+--session-arg "remove_key:key='account-hash-1fed34baa6807a7868bb18f91b161d99ebf21763810fe4c92e39775d10bbf1f8"
 ```
 
-The resulting account should not contain the associated key that you just removed.
+The resulting account should not contain the associated key that was just removed.
 
 <details>
 <summary>Account details</summary>
-
-### FOR EXAMPLE ONLY, PLEASE UPDATE PRIOR TO EXECUTING
 
 ```json
 "Account": {
@@ -373,10 +334,6 @@ The resulting account should not contain the associated key that you just remove
       "associated_keys": [
         {
           "account_hash": "account-hash-04a9691a9f8f05a0f08bd686f188b27c7dbcd644b415759fd3ca043d916ea02f",
-          "weight": 1
-        },
-        {
-          "account_hash": "account-hash-1fed34baa6807a7868bb18f91b161d99ebf21763810fe4c92e39775d10bbf1f8",
           "weight": 1
         },
         {

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ The purpose of this repository is to provide an example of how to integrate key 
 git clone https://github.com/cryofracture/multi-sig && cd multi-sig
 ```
 
-## Step 2: Build the sample Wasm provided
+## Step 2: Build and test the sample Wasm provided
 
 ```bash
 rustup update
 make clean
 make prepare
-make build-contracts
+make test
 ```
 
 ## Step 3: Increase the primary key's weight to set thresholds

--- a/README.md
+++ b/README.md
@@ -265,11 +265,11 @@ casper-client send-deploy --node-address https://rpc.testnet.casperlabs.io -i he
 The `hello_world.wasm` will run and add a named key to the account.
 
 
-## Step 8: Remove a key from the account
+## Removing a compromised key from the account
 
-This example adds a fourth associated key with `account-hash-77ea2e433c94c9cb8303942335da458672249d38c1fa5d1d7a7500b862ff52a4`, and then removes it using the `remove_account.wasm` session code. The goal is to show how to remove a key that may have been compromised.
+This example shows how to remove a key that may have been compromised. The example adds another associated key  only to remove it using the `remove_account.wasm` session code. 
 
->**Caution**: If you remove one of the existing keys without adding the fourth associated key, the account will become unusable since none of the remaining keys will meet the required weight for key management. Changing weights or adding new associated keys would become impossible.
+>**Caution**: Before removing a key, ensure the remaining associated keys can combine their weight to meet the threshold for key management. Otherwise, the account could become unusable. Changing key weights or adding new associated keys would only be possible by meeting the key management threshold. Proceed with caution.
 
 ### FOR EXAMPLE ONLY, PLEASE UPDATE PRIOR TO EXECUTING
 

--- a/tests/src/integration_tests.rs
+++ b/tests/src/integration_tests.rs
@@ -518,29 +518,13 @@ mod tests {
 
         // Step 7: Send a multi-signature deploy from an associated key
 
-        // Let's first update deployement threshold to 5, above default account wieght
-        let update_threshold_request = ExecuteRequestBuilder::standard(
-            *DEFAULT_ACCOUNT_ADDR,
-            UPDATE_THRESHOLDS_WASM,
-            runtime_args! {
-                RUNTIME_ARG_NEW_DEPLOYMENT_THRESHOLD =>  Weight::new(5),
-                RUNTIME_ARG_NEW_KEY_MANAGEMENT_THRESHOLD => Weight::new(5),
-            },
-        )
-        .build();
-
-        builder
-            .exec(update_threshold_request)
-            .expect_success()
-            .commit();
-
-        // This deploy request should fail as DEFAULT_ACCOUNT_ADDR + USER_1_ACCOUNT has weight 4, below deployment threshold of 5
+        // This deploy request should fail as USER_1_ACCOUNT has weight 1, below deployment threshold of 2
         let deploy_item = DeployItemBuilder::new()
             .with_empty_payment_bytes(runtime_args! {
                 ARG_AMOUNT => *DEFAULT_PAYMENT
             })
             .with_session_code(session_code.clone(), session_args.clone())
-            .with_authorization_keys(&[*DEFAULT_ACCOUNT_ADDR, USER_1_ACCOUNT])
+            .with_authorization_keys(&[USER_1_ACCOUNT])
             .with_address(*DEFAULT_ACCOUNT_ADDR)
             .build();
 
@@ -548,14 +532,14 @@ mod tests {
 
         builder.exec(deploy_request).expect_failure();
 
-        // This deploy request should succeed as DEFAULT_ACCOUNT_ADDR + USER_1_ACCOUNT + USER_2_ACCOUNT has weight 5, equal deployment threshold of 5
+        // This deploy request should succeed as USER_1_ACCOUNT + USER_2_ACCOUNT have weight 2, equal deployment threshold of 2
 
         let deploy_item = DeployItemBuilder::new()
             .with_empty_payment_bytes(runtime_args! {
                 ARG_AMOUNT => *DEFAULT_PAYMENT
             })
             .with_session_code(session_code, session_args)
-            .with_authorization_keys(&[*DEFAULT_ACCOUNT_ADDR, USER_1_ACCOUNT, USER_2_ACCOUNT])
+            .with_authorization_keys(&[USER_1_ACCOUNT, USER_2_ACCOUNT])
             .with_address(*DEFAULT_ACCOUNT_ADDR)
             .build();
 

--- a/tests/src/integration_tests.rs
+++ b/tests/src/integration_tests.rs
@@ -496,7 +496,7 @@ mod tests {
         // This request should succeed as DEFAULT_ACCOUNT_ADDR has weight 3, above or equal key management threshold && deployment threshold
         builder.exec(add_key_request).expect_success().commit();
 
-        // Step 6: Send a multi-signature deploy from the primary account
+        // Step 6: Send a deploy from the primary account
         let session_code = PathBuf::from(CONTRACT_WASM);
         let session_args = runtime_args! {
             RUNTIME_ARG_NAME => TEST_VALUE,
@@ -513,7 +513,7 @@ mod tests {
 
         let deploy_request = ExecuteRequestBuilder::from_deploy_item(deploy_item).build();
 
-        // This request should succeed as DEFAULT_ACCOUNT_ADDR has weight 3, equal deployment threshold
+        // This request should succeed as DEFAULT_ACCOUNT_ADDR has weight 3, greater than the deployment threshold
         builder.exec(deploy_request).expect_success().commit();
 
         // Step 7: Send a multi-signature deploy from an associated key


### PR DESCRIPTION
- Updated README as discussed
- Figured out how to send a multi-sig deploy from an associated key
   - The `--session-code` argument points to the primary account
   - Then, user_1 and user_2 sign the deploy with their keys
   - In this case, we can keep the thresholds as set up (deployment=2, key management=3) 
- Updated step 7 in the integration test, to match the README flow